### PR TITLE
Improve the unit and integration tests

### DIFF
--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/Telemetry.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/Telemetry.java
@@ -16,6 +16,7 @@
 package software.amazon.s3.analyticsaccelerator.common.telemetry;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
@@ -81,11 +82,13 @@ public interface Telemetry extends Closeable {
    * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
    * @return an instance of {@link T} that returns the same result as the one passed in.
+   * @throws IOException if the underlying operation threw an IOException
    */
   default <T> T measureJoin(
       @NonNull TelemetryLevel level,
       @NonNull OperationSupplier operationSupplier,
-      @NonNull CompletableFuture<T> operationCode) {
+      @NonNull CompletableFuture<T> operationCode)
+      throws IOException {
     if (operationCode.isDone()) {
       return operationCode.join();
     } else {
@@ -147,9 +150,10 @@ public interface Telemetry extends Closeable {
    * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
    * @return an instance of {@link T} that returns the same result as the one passed in.
+   * @throws IOException if the underlying operation threw an IOException
    */
   default <T> T measureJoinCritical(
-      OperationSupplier operationSupplier, CompletableFuture<T> operationCode) {
+      OperationSupplier operationSupplier, CompletableFuture<T> operationCode) throws IOException {
     return measureJoin(TelemetryLevel.CRITICAL, operationSupplier, operationCode);
   }
 
@@ -207,9 +211,10 @@ public interface Telemetry extends Closeable {
    * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
    * @return an instance of {@link T} that returns the same result as the one passed in.
+   * @throws IOException if the underlying operation threw an IOException
    */
   default <T> T measureJoinStandard(
-      OperationSupplier operationSupplier, CompletableFuture<T> operationCode) {
+      OperationSupplier operationSupplier, CompletableFuture<T> operationCode) throws IOException {
     return measureJoin(TelemetryLevel.STANDARD, operationSupplier, operationCode);
   }
 
@@ -267,9 +272,10 @@ public interface Telemetry extends Closeable {
    * @param operationSupplier operation to record this execution as.
    * @param operationCode the future to measure the execution of.
    * @return an instance of {@link T} that returns the same result as the one passed in.
+   * @throws IOException if the underlying operation threw an IOException
    */
   default <T> T measureJoinVerbose(
-      OperationSupplier operationSupplier, CompletableFuture<T> operationCode) {
+      OperationSupplier operationSupplier, CompletableFuture<T> operationCode) throws IOException {
     return measureJoin(TelemetryLevel.VERBOSE, operationSupplier, operationCode);
   }
 

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/TelemetryDatapoint.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/TelemetryDatapoint.java
@@ -117,7 +117,9 @@ public abstract class TelemetryDatapoint {
       return buildCore();
     }
 
-    /** @return new instance of whatever this builder builds */
+    /**
+     * @return new instance of whatever this builder builds
+     */
     protected abstract T buildCore();
   }
 }

--- a/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/TelemetryDatapointMeasurement.java
+++ b/common/src/main/java/software/amazon/s3/analyticsaccelerator/common/telemetry/TelemetryDatapointMeasurement.java
@@ -100,7 +100,9 @@ public abstract class TelemetryDatapointMeasurement {
       return buildCore();
     }
 
-    /** @return new instance of whatever this builder builds */
+    /**
+     * @return new instance of whatever this builder builds
+     */
     protected abstract T buildCore();
   }
 }

--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ConcurrencyCorrectnessTest.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ConcurrencyCorrectnessTest.java
@@ -33,38 +33,57 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
   @ParameterizedTest
   @MethodSource("sequentialReads")
   void testSequentialReads(
+      S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       DATInputStreamConfigurationKind configuration)
       throws IOException, InterruptedException, ExecutionException {
     testDATReadConcurrency(
-        s3Object, streamReadPattern, configuration, CONCURRENCY_LEVEL, CONCURRENCY_ITERATIONS);
+        s3ClientKind,
+        s3Object,
+        streamReadPattern,
+        configuration,
+        CONCURRENCY_LEVEL,
+        CONCURRENCY_ITERATIONS);
   }
 
   @ParameterizedTest
   @MethodSource("skippingReads")
   void testSkippingReads(
+      S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       DATInputStreamConfigurationKind configuration)
       throws IOException, InterruptedException, ExecutionException {
     testDATReadConcurrency(
-        s3Object, streamReadPattern, configuration, CONCURRENCY_LEVEL, CONCURRENCY_ITERATIONS);
+        s3ClientKind,
+        s3Object,
+        streamReadPattern,
+        configuration,
+        CONCURRENCY_LEVEL,
+        CONCURRENCY_ITERATIONS);
   }
 
   @ParameterizedTest
   @MethodSource("parquetReads")
   void testQuasiParquetReads(
+      S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       DATInputStreamConfigurationKind configuration)
       throws IOException, InterruptedException, ExecutionException {
     testDATReadConcurrency(
-        s3Object, streamReadPattern, configuration, CONCURRENCY_LEVEL, CONCURRENCY_ITERATIONS);
+        s3ClientKind,
+        s3Object,
+        streamReadPattern,
+        configuration,
+        CONCURRENCY_LEVEL,
+        CONCURRENCY_ITERATIONS);
   }
 
   static Stream<Arguments> sequentialReads() {
     return argumentsFor(
+        getS3ClientKinds(),
         S3Object.smallAndMediumObjects(),
         sequentialPatterns(),
         getS3SeekableInputStreamConfigurations());
@@ -72,6 +91,7 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
 
   static Stream<Arguments> skippingReads() {
     return argumentsFor(
+        getS3ClientKinds(),
         S3Object.smallAndMediumObjects(),
         skippingPatterns(),
         getS3SeekableInputStreamConfigurations());
@@ -79,6 +99,7 @@ public class ConcurrencyCorrectnessTest extends IntegrationTestBase {
 
   static Stream<Arguments> parquetReads() {
     return argumentsFor(
+        getS3ClientKinds(),
         S3Object.smallAndMediumObjects(),
         parquetPatterns(),
         getS3SeekableInputStreamConfigurations());

--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ExceptionCorrectnessTest.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ExceptionCorrectnessTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.s3.analyticsaccelerator.access;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.s3.analyticsaccelerator.S3SdkObjectClient;
+import software.amazon.s3.analyticsaccelerator.S3SeekableInputStream;
+import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguration;
+import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamFactory;
+import software.amazon.s3.analyticsaccelerator.util.S3URI;
+
+public class ExceptionCorrectnessTest extends IntegrationTestBase {
+
+  private static final String NON_EXISTENT_OBJECT = "non-existent.bin";
+
+  private enum ReadMethod {
+    SIMPLE_READ {
+      @SuppressFBWarnings(
+          value = "RR_NOT_CHECKED",
+          justification = "Test only cares about exception throwing, not the actual bytes read")
+      void doRead(S3SeekableInputStream stream) throws IOException {
+        stream.read();
+      }
+    },
+    BUFFER_READ {
+      @SuppressFBWarnings(
+          value = "RR_NOT_CHECKED",
+          justification = "Test only cares about exception throwing, not the actual bytes read")
+      void doRead(S3SeekableInputStream stream) throws IOException {
+        stream.read(new byte[10], 0, 10);
+      }
+    },
+    TAIL_READ {
+      @SuppressFBWarnings(
+          value = "RR_NOT_CHECKED",
+          justification = "Test only cares about exception throwing, not the actual bytes read")
+      void doRead(S3SeekableInputStream stream) throws IOException {
+        stream.readTail(new byte[10], 0, 10);
+      }
+    };
+
+    abstract void doRead(S3SeekableInputStream stream) throws IOException;
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTestParameters")
+  void testNonExistentObjectThrowsRightException(S3ClientKind clientKind, ReadMethod readMethod) {
+    final S3ExecutionConfiguration config = this.getS3ExecutionContext().getConfiguration();
+    final S3URI nonExistentURI =
+        S3URI.of(config.getBucket(), config.getPrefix() + NON_EXISTENT_OBJECT);
+    S3AsyncClient s3AsyncClient = clientKind.getS3Client(getS3ExecutionContext());
+    S3SeekableInputStreamFactory factory = createInputStreamFactory(s3AsyncClient);
+    S3SeekableInputStream inputStream = factory.createStream(nonExistentURI);
+    assertThrows(FileNotFoundException.class, () -> readMethod.doRead(inputStream));
+  }
+
+  private static Stream<Arguments> provideTestParameters() {
+    return Stream.of(S3ClientKind.SDK_V2_CRT_ASYNC, S3ClientKind.SDK_V2_JAVA_ASYNC)
+        .flatMap(
+            clientKind ->
+                Stream.of(ReadMethod.values())
+                    .map(readMethod -> Arguments.of(clientKind, readMethod)));
+  }
+
+  private static S3SeekableInputStreamFactory createInputStreamFactory(
+      S3AsyncClient s3AsyncClient) {
+    return new S3SeekableInputStreamFactory(
+        new S3SdkObjectClient(s3AsyncClient), S3SeekableInputStreamConfiguration.DEFAULT);
+  }
+}

--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ExceptionCorrectnessTest.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ExceptionCorrectnessTest.java
@@ -77,7 +77,7 @@ public class ExceptionCorrectnessTest extends IntegrationTestBase {
   }
 
   private static Stream<Arguments> provideTestParameters() {
-    return Stream.of(S3ClientKind.SDK_V2_CRT_ASYNC, S3ClientKind.SDK_V2_JAVA_ASYNC)
+    return getS3ClientKinds().stream()
         .flatMap(
             clientKind ->
                 Stream.of(ReadMethod.values())

--- a/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ReadCorrectnessTest.java
+++ b/input-stream/src/integrationTest/java/software/amazon/s3/analyticsaccelerator/access/ReadCorrectnessTest.java
@@ -26,35 +26,39 @@ public class ReadCorrectnessTest extends IntegrationTestBase {
   @ParameterizedTest
   @MethodSource("sequentialReads")
   void testSequentialReads(
+      S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       DATInputStreamConfigurationKind configuration)
       throws IOException {
-    testAndCompareStreamReadPattern(s3Object, streamReadPattern, configuration);
+    testAndCompareStreamReadPattern(s3ClientKind, s3Object, streamReadPattern, configuration);
   }
 
   @ParameterizedTest
   @MethodSource("skippingReads")
   void testSkippingReads(
+      S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       DATInputStreamConfigurationKind configuration)
       throws IOException {
-    testAndCompareStreamReadPattern(s3Object, streamReadPattern, configuration);
+    testAndCompareStreamReadPattern(s3ClientKind, s3Object, streamReadPattern, configuration);
   }
 
   @ParameterizedTest
   @MethodSource("parquetReads")
   void testQuasiParquetReads(
+      S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPatternKind streamReadPattern,
       DATInputStreamConfigurationKind configuration)
       throws IOException {
-    testAndCompareStreamReadPattern(s3Object, streamReadPattern, configuration);
+    testAndCompareStreamReadPattern(s3ClientKind, s3Object, streamReadPattern, configuration);
   }
 
   static Stream<Arguments> sequentialReads() {
     return argumentsFor(
+        getS3ClientKinds(),
         S3Object.smallAndMediumObjects(),
         sequentialPatterns(),
         getS3SeekableInputStreamConfigurations());
@@ -62,6 +66,7 @@ public class ReadCorrectnessTest extends IntegrationTestBase {
 
   static Stream<Arguments> skippingReads() {
     return argumentsFor(
+        getS3ClientKinds(),
         S3Object.smallAndMediumObjects(),
         skippingPatterns(),
         getS3SeekableInputStreamConfigurations());
@@ -69,6 +74,7 @@ public class ReadCorrectnessTest extends IntegrationTestBase {
 
   static Stream<Arguments> parquetReads() {
     return argumentsFor(
+        getS3ClientKinds(),
         S3Object.smallAndMediumObjects(),
         parquetPatterns(),
         getS3SeekableInputStreamConfigurations());

--- a/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/BenchmarkBase.java
+++ b/input-stream/src/jmh/java/software/amazon/s3/analyticsaccelerator/benchmarks/BenchmarkBase.java
@@ -88,6 +88,13 @@ public abstract class BenchmarkBase extends ExecutionBase {
   protected abstract StreamReadPatternKind getReadPatternKind();
 
   /**
+   * Returns current client kind
+   *
+   * @return {@link S3ClientKind}
+   */
+  protected abstract S3ClientKind getClientKind();
+
+  /**
    * Benchmarks can override this to return the {@link DATInputStreamConfigurationKind}
    *
    * @return {@link DATInputStreamConfigurationKind}
@@ -116,6 +123,7 @@ public abstract class BenchmarkBase extends ExecutionBase {
   protected void executeReadPatternOnDAT() throws IOException {
     S3Object s3Object = this.getObject();
     executeReadPatternOnDAT(
+        this.getClientKind(),
         s3Object,
         this.getReadPatternKind().getStreamReadPattern(s3Object),
         // Use default configuration
@@ -131,6 +139,9 @@ public abstract class BenchmarkBase extends ExecutionBase {
   protected void executeReadPatternDirectly() throws IOException {
     S3Object s3Object = this.getObject();
     executeReadPatternDirectly(
-        s3Object, this.getReadPatternKind().getStreamReadPattern(s3Object), Optional.empty());
+        this.getClientKind(),
+        s3Object,
+        this.getReadPatternKind().getStreamReadPattern(s3Object),
+        Optional.empty());
   }
 }

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/RandomAccessReadable.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/RandomAccessReadable.java
@@ -25,8 +25,9 @@ public interface RandomAccessReadable extends Closeable {
    * Returns object metadata.
    *
    * @return the metadata of the object.
+   * @throws IOException if an I/O error occurs
    */
-  ObjectMetadata metadata();
+  ObjectMetadata metadata() throws IOException;
 
   /**
    * Reads a byte from the underlying object

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStream.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/S3SeekableInputStream.java
@@ -242,8 +242,9 @@ public class S3SeekableInputStream extends SeekableInputStream {
    * Returns the length of the byte content of the stream.
    *
    * @return the length of the byte content of the stream.
+   * @throws IOException if an I/O error occurs
    */
-  private long getContentLength() {
+  private long getContentLength() throws IOException {
     return this.logicalIO.metadata().getContentLength();
   }
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/DefaultLogicalIOImpl.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/logical/impl/DefaultLogicalIOImpl.java
@@ -114,9 +114,10 @@ public class DefaultLogicalIOImpl implements LogicalIO {
    * Returns object metadata.
    *
    * @return object metadata
+   * @throws IOException if an I/O error occurs
    */
   @Override
-  public ObjectMetadata metadata() {
+  public ObjectMetadata metadata() throws IOException {
     return this.physicalIO.metadata();
   }
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Blob.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Blob.java
@@ -16,6 +16,7 @@
 package software.amazon.s3.analyticsaccelerator.io.physical.data;
 
 import java.io.Closeable;
+import java.io.IOException;
 import lombok.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +26,7 @@ import software.amazon.s3.analyticsaccelerator.common.telemetry.Telemetry;
 import software.amazon.s3.analyticsaccelerator.io.physical.plan.IOPlan;
 import software.amazon.s3.analyticsaccelerator.io.physical.plan.IOPlanExecution;
 import software.amazon.s3.analyticsaccelerator.io.physical.plan.IOPlanState;
+import software.amazon.s3.analyticsaccelerator.request.Range;
 import software.amazon.s3.analyticsaccelerator.request.ReadMode;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 import software.amazon.s3.analyticsaccelerator.util.StreamAttributes;
@@ -64,8 +66,9 @@ public class Blob implements Closeable {
    *
    * @param pos The position to read
    * @return an unsigned int representing the byte that was read
+   * @throws IOException if an I/O error occurs
    */
-  public int read(long pos) {
+  public int read(long pos) throws IOException {
     Preconditions.checkArgument(pos >= 0, "`pos` must be non-negative");
     blockManager.makePositionAvailable(pos, ReadMode.SYNC);
     return blockManager.getBlock(pos).get().read(pos);
@@ -79,8 +82,9 @@ public class Blob implements Closeable {
    * @param len length of data to be read
    * @param pos the position to begin reading from
    * @return the total number of bytes read into the buffer
+   * @throws IOException if an I/O error occurs
    */
-  public int read(byte[] buf, int off, int len, long pos) {
+  public int read(byte[] buf, int off, int len, long pos) throws IOException {
     Preconditions.checkArgument(0 <= pos, "`pos` must not be negative");
     Preconditions.checkArgument(pos < contentLength(), "`pos` must be less than content length");
     Preconditions.checkArgument(0 <= off, "`off` must not be negative");
@@ -133,12 +137,10 @@ public class Blob implements Closeable {
                 .build(),
         () -> {
           try {
-            plan.getPrefetchRanges()
-                .forEach(
-                    range -> {
-                      this.blockManager.makeRangeAvailable(
-                          range.getStart(), range.getLength(), ReadMode.ASYNC);
-                    });
+            for (Range range : plan.getPrefetchRanges()) {
+              this.blockManager.makeRangeAvailable(
+                  range.getStart(), range.getLength(), ReadMode.ASYNC);
+            }
 
             return IOPlanExecution.builder().state(IOPlanState.SUBMITTED).build();
           } catch (Exception e) {
@@ -148,7 +150,7 @@ public class Blob implements Closeable {
         });
   }
 
-  private long contentLength() {
+  private long contentLength() throws IOException {
     return metadataStore.get(s3URI).getContentLength();
   }
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/Block.java
@@ -16,6 +16,7 @@
 package software.amazon.s3.analyticsaccelerator.io.physical.data;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import lombok.Getter;
 import lombok.NonNull;
@@ -134,8 +135,9 @@ public class Block implements Closeable {
    *
    * @param pos The position to read
    * @return an unsigned int representing the byte that was read
+   * @throws IOException if an I/O error occurs
    */
-  public int read(long pos) {
+  public int read(long pos) throws IOException {
     Preconditions.checkArgument(0 <= pos, "`pos` must not be negative");
 
     byte[] content = this.getData();
@@ -150,8 +152,9 @@ public class Block implements Closeable {
    * @param len length of data to be read
    * @param pos the position to begin reading from
    * @return the total number of bytes read into the buffer
+   * @throws IOException if an I/O error occurs
    */
-  public int read(byte @NonNull [] buf, int off, int len, long pos) {
+  public int read(byte @NonNull [] buf, int off, int len, long pos) throws IOException {
     Preconditions.checkArgument(0 <= pos, "`pos` must not be negative");
     Preconditions.checkArgument(0 <= off, "`off` must not be negative");
     Preconditions.checkArgument(0 <= len, "`len` must not be negative");
@@ -195,8 +198,9 @@ public class Block implements Closeable {
    * data is fully available.
    *
    * @return the bytes fetched by the issued {@link GetRequest}.
+   * @throws IOException if an I/O error occurs
    */
-  private byte[] getData() {
+  private byte[] getData() throws IOException {
     return this.telemetry.measureJoinCritical(
         () ->
             Operation.builder()

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManager.java
@@ -16,6 +16,7 @@
 package software.amazon.s3.analyticsaccelerator.io.physical.data;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -112,8 +113,9 @@ public class BlockManager implements Closeable {
    *
    * @param pos the position of the byte
    * @param readMode whether this ask corresponds to a sync or async read
+   * @throws IOException if an I/O error occurs
    */
-  public synchronized void makePositionAvailable(long pos, ReadMode readMode) {
+  public synchronized void makePositionAvailable(long pos, ReadMode readMode) throws IOException {
     Preconditions.checkArgument(0 <= pos, "`pos` must not be negative");
 
     // Position is already available --> return corresponding block
@@ -124,7 +126,7 @@ public class BlockManager implements Closeable {
     makeRangeAvailable(pos, 1, readMode);
   }
 
-  private boolean isRangeAvailable(long pos, long len) {
+  private boolean isRangeAvailable(long pos, long len) throws IOException {
     Preconditions.checkArgument(0 <= pos, "`pos` must not be negative");
     Preconditions.checkArgument(0 <= len, "`len` must not be negative");
 
@@ -147,8 +149,10 @@ public class BlockManager implements Closeable {
    * @param pos start of a read
    * @param len length of the read
    * @param readMode whether this ask corresponds to a sync or async read
+   * @throws IOException if an I/O error occurs
    */
-  public synchronized void makeRangeAvailable(long pos, long len, ReadMode readMode) {
+  public synchronized void makeRangeAvailable(long pos, long len, ReadMode readMode)
+      throws IOException {
     Preconditions.checkArgument(0 <= pos, "`pos` must not be negative");
     Preconditions.checkArgument(0 <= len, "`len` must not be negative");
 
@@ -208,11 +212,11 @@ public class BlockManager implements Closeable {
         });
   }
 
-  private long getLastObjectByte() {
+  private long getLastObjectByte() throws IOException {
     return this.metadataStore.get(s3URI).getContentLength() - 1;
   }
 
-  private long truncatePos(long pos) {
+  private long truncatePos(long pos) throws IOException {
     Preconditions.checkArgument(0 <= pos, "`pos` must not be negative");
 
     return Math.min(pos, getLastObjectByte());

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStore.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStore.java
@@ -16,6 +16,7 @@
 package software.amazon.s3.analyticsaccelerator.io.physical.data;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -87,8 +88,9 @@ public class BlockStore implements Closeable {
    * @param pos a byte position
    * @return the position of the next byte NOT present in the BlockStore or empty if all bytes are
    *     present
+   * @throws IOException if an I/O error occurs
    */
-  public OptionalLong findNextMissingByte(long pos) {
+  public OptionalLong findNextMissingByte(long pos) throws IOException {
     Preconditions.checkArgument(0 <= pos, "`pos` must not be negative");
 
     long nextMissingByte = pos;
@@ -113,7 +115,7 @@ public class BlockStore implements Closeable {
     this.blocks.add(block);
   }
 
-  private long getLastObjectByte() {
+  private long getLastObjectByte() throws IOException {
     return this.metadataStore.get(s3URI).getContentLength() - 1;
   }
 

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlanner.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlanner.java
@@ -15,6 +15,7 @@
  */
 package software.amazon.s3.analyticsaccelerator.io.physical.data;
 
+import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.OptionalLong;
@@ -46,8 +47,9 @@ public class IOPlanner {
    * @param end the end of a read
    * @param lastObjectByte the zero-indexed position of the last object byte
    * @return a list of Ranges that need to be fetched
+   * @throws IOException if an I/O error occurs
    */
-  public List<Range> planRead(long pos, long end, long lastObjectByte) {
+  public List<Range> planRead(long pos, long end, long lastObjectByte) throws IOException {
     Preconditions.checkArgument(0 <= pos, "`pos` must be non-negative");
     Preconditions.checkArgument(pos <= end, "`pos` must be less than or equal to `end`");
     Preconditions.checkArgument(

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/MetadataStore.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/data/MetadataStore.java
@@ -17,6 +17,7 @@ package software.amazon.s3.analyticsaccelerator.io.physical.data;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -77,8 +78,9 @@ public class MetadataStore implements Closeable {
    *
    * @param s3URI the object to fetch the metadata for
    * @return returns the {@link ObjectMetadata}.
+   * @throws IOException if an I/O error occurs
    */
-  public ObjectMetadata get(S3URI s3URI) {
+  public ObjectMetadata get(S3URI s3URI) throws IOException {
     return telemetry.measureJoinCritical(
         () ->
             Operation.builder()

--- a/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImpl.java
+++ b/input-stream/src/main/java/software/amazon/s3/analyticsaccelerator/io/physical/impl/PhysicalIOImpl.java
@@ -87,9 +87,10 @@ public class PhysicalIOImpl implements PhysicalIO {
    * Returns object metadata.
    *
    * @return the metadata of the object.
+   * @throws IOException if an I/O error occurs
    */
   @Override
-  public ObjectMetadata metadata() {
+  public ObjectMetadata metadata() throws IOException {
     return metadataStore.get(s3URI);
   }
 
@@ -98,6 +99,7 @@ public class PhysicalIOImpl implements PhysicalIO {
    *
    * @param pos the position to read
    * @return an unsigned int representing the byte that was read
+   * @throws IOException if an I/O error occurs
    */
   @Override
   public int read(long pos) throws IOException {
@@ -126,6 +128,7 @@ public class PhysicalIOImpl implements PhysicalIO {
    * @param len length of data to be read
    * @param pos the position to begin reading from
    * @return the total number of bytes read into the buffer
+   * @throws IOException if an I/O error occurs
    */
   @Override
   public int read(byte[] buf, int off, int len, long pos) throws IOException {
@@ -156,6 +159,7 @@ public class PhysicalIOImpl implements PhysicalIO {
    * @param off start position in buffer at which data is written
    * @param len the number of bytes to read; the n-th byte should be the last byte of the stream.
    * @return the total number of bytes read into the buffer
+   * @throws IOException if an I/O error occurs
    */
   @Override
   public int readTail(byte[] buf, int off, int len) throws IOException {
@@ -196,7 +200,7 @@ public class PhysicalIOImpl implements PhysicalIO {
         () -> blobStore.get(s3URI, streamContext).execute(ioPlan));
   }
 
-  private long contentLength() {
+  private long contentLength() throws IOException {
     return metadata().getContentLength();
   }
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchTailTaskTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/logical/parquet/ParquetPrefetchTailTaskTest.java
@@ -79,7 +79,7 @@ public class ParquetPrefetchTailTaskTest {
   }
 
   @Test
-  void testTailPrefetch() {
+  void testTailPrefetch() throws IOException {
     LogicalIOConfiguration configuration =
         LogicalIOConfiguration.builder().prefetchFooterEnabled(true).build();
 

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStoreTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobStoreTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
@@ -70,7 +71,7 @@ public class BlobStoreTest {
   }
 
   @Test
-  public void testGetReturnsReadableBlob() {
+  public void testGetReturnsReadableBlob() throws IOException {
     // Given: a BlobStore with an underlying metadata store and object client
     final String TEST_DATA = "test-data";
     ObjectClient objectClient = new FakeObjectClient("test-data");

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlobTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static software.amazon.s3.analyticsaccelerator.io.physical.plan.IOPlanState.SUBMITTED;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
@@ -62,7 +63,7 @@ public class BlobTest {
   }
 
   @Test
-  public void testSingleByteReadReturnsCorrectByte() {
+  public void testSingleByteReadReturnsCorrectByte() throws IOException {
     // Given: test Blob
     Blob blob = getTestBlob(TEST_DATA);
 
@@ -80,7 +81,7 @@ public class BlobTest {
   }
 
   @Test
-  public void testBufferedReadReturnsCorrectByte() {
+  public void testBufferedReadReturnsCorrectByte() throws IOException {
     // Given: test Blob
     Blob blob = getTestBlob(TEST_DATA);
 
@@ -96,7 +97,7 @@ public class BlobTest {
   }
 
   @Test
-  public void testBufferedReadTestOverlappingRanges() {
+  public void testBufferedReadTestOverlappingRanges() throws IOException {
     // Given: test Blob
     Blob blob = getTestBlob(TEST_DATA);
 
@@ -128,7 +129,7 @@ public class BlobTest {
   }
 
   @Test
-  public void testExecuteSubmitsCorrectRanges() {
+  public void testExecuteSubmitsCorrectRanges() throws IOException {
     // Given: test blob and an IOPlan
     MetadataStore metadataStore = mock(MetadataStore.class);
     BlockManager blockManager = mock(BlockManager.class);

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManagerTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockManagerTest.java
@@ -26,6 +26,7 @@ import static software.amazon.s3.analyticsaccelerator.util.Constants.ONE_MB;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -89,7 +90,7 @@ public class BlockManagerTest {
   }
 
   @Test
-  void testGetBlockIsEmpty() {
+  void testGetBlockIsEmpty() throws IOException {
     // Given
     BlockManager blockManager = getTestBlockManager(42);
 
@@ -100,7 +101,7 @@ public class BlockManagerTest {
   }
 
   @Test
-  void testGetBlockReturnsAvailableBlock() {
+  void testGetBlockReturnsAvailableBlock() throws IOException {
     // Given
     BlockManager blockManager = getTestBlockManager(65 * ONE_KB);
 
@@ -113,7 +114,7 @@ public class BlockManagerTest {
   }
 
   @Test
-  void testMakePositionAvailableRespectsReadAhead() {
+  void testMakePositionAvailableRespectsReadAhead() throws IOException {
     // Given
     final int objectSize = (int) PhysicalIOConfiguration.DEFAULT.getReadAheadBytes() + ONE_KB;
     ObjectClient objectClient = mock(ObjectClient.class);
@@ -133,7 +134,7 @@ public class BlockManagerTest {
   }
 
   @Test
-  void testMakePositionAvailableRespectsLastObjectByte() {
+  void testMakePositionAvailableRespectsLastObjectByte() throws IOException {
     // Given
     final int objectSize = 5 * ONE_KB;
     ObjectClient objectClient = mock(ObjectClient.class);
@@ -151,7 +152,7 @@ public class BlockManagerTest {
   }
 
   @Test
-  void testMakeRangeAvailableDoesNotOverread() {
+  void testMakeRangeAvailableDoesNotOverread() throws IOException {
     // Given: BM with 0-64KB and 64KB+1 to 128KB
     ObjectClient objectClient = mock(ObjectClient.class);
     BlockManager blockManager = getTestBlockManager(objectClient, 128 * ONE_KB);
@@ -174,7 +175,7 @@ public class BlockManagerTest {
   }
 
   @Test
-  void regressionTestSequentialPrefetchShouldNotShrinkRanges() {
+  void regressionTestSequentialPrefetchShouldNotShrinkRanges() throws IOException {
     // Given: BlockManager with some blocks loaded
     ObjectClient objectClient = mock(ObjectClient.class);
     BlockManager blockManager =
@@ -204,16 +205,17 @@ public class BlockManagerTest {
                             "block should have been available because it was requested before")));
   }
 
-  private BlockManager getTestBlockManager(int size) {
+  private BlockManager getTestBlockManager(int size) throws IOException {
     return getTestBlockManager(mock(ObjectClient.class), size);
   }
 
-  private BlockManager getTestBlockManager(ObjectClient objectClient, int size) {
+  private BlockManager getTestBlockManager(ObjectClient objectClient, int size) throws IOException {
     return getTestBlockManager(objectClient, size, PhysicalIOConfiguration.DEFAULT);
   }
 
   private BlockManager getTestBlockManager(
-      ObjectClient objectClient, int size, PhysicalIOConfiguration configuration) {
+      ObjectClient objectClient, int size, PhysicalIOConfiguration configuration)
+      throws IOException {
     S3URI testUri = S3URI.of("foo", "bar");
     when(objectClient.getObject(any(), any()))
         .thenReturn(

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStoreTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockStoreTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
 import java.util.Optional;
 import java.util.OptionalLong;
 import org.junit.jupiter.api.Test;
@@ -57,7 +58,7 @@ public class BlockStoreTest {
   }
 
   @Test
-  public void test__blockStore__findNextMissingByteCorrect() {
+  public void test__blockStore__findNextMissingByteCorrect() throws IOException {
     // Given: BlockStore with blocks (2,3), (5,10), (12,15)
     final String X_TIMES_16 = "xxxxxxxxxxxxxxxx";
     FakeObjectClient fakeObjectClient = new FakeObjectClient(X_TIMES_16);

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/BlockTest.java
@@ -18,6 +18,7 @@ package software.amazon.s3.analyticsaccelerator.io.physical.data;
 import static org.junit.jupiter.api.Assertions.*;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
@@ -33,7 +34,7 @@ public class BlockTest {
   private static final S3URI TEST_URI = S3URI.of("foo", "bar");
 
   @Test
-  public void testSingleByteReadReturnsCorrectByte() {
+  public void testSingleByteReadReturnsCorrectByte() throws IOException {
     // Given: a Block containing "test-data"
     final String TEST_DATA = "test-data";
     ObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);
@@ -59,7 +60,7 @@ public class BlockTest {
   }
 
   @Test
-  public void testBufferedReadReturnsCorrectBytes() {
+  public void testBufferedReadReturnsCorrectBytes() throws IOException {
     // Given: a Block containing "test-data"
     final String TEST_DATA = "test-data";
     ObjectClient fakeObjectClient = new FakeObjectClient(TEST_DATA);

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlannerTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/IOPlannerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
@@ -44,7 +45,7 @@ public class IOPlannerTest {
   }
 
   @Test
-  void testPlanReadBoundaries() {
+  void testPlanReadBoundaries() throws IOException {
     // Given: an empty BlockStore
     final int OBJECT_SIZE = 10_000;
     MetadataStore mockMetadataStore = mock(MetadataStore.class);
@@ -59,7 +60,7 @@ public class IOPlannerTest {
   }
 
   @Test
-  public void testPlanReadNoopWhenBlockStoreEmpty() {
+  public void testPlanReadNoopWhenBlockStoreEmpty() throws IOException {
     // Given: an empty BlockStore
     final int OBJECT_SIZE = 10_000;
     MetadataStore mockMetadataStore = mock(MetadataStore.class);
@@ -79,7 +80,7 @@ public class IOPlannerTest {
   }
 
   @Test
-  public void testPlanReadDoesNotDoubleRead() {
+  public void testPlanReadDoesNotDoubleRead() throws IOException {
     // Given: a BlockStore with a (100,200) block in it
     final int OBJECT_SIZE = 10_000;
     byte[] content = new byte[OBJECT_SIZE];
@@ -103,7 +104,7 @@ public class IOPlannerTest {
   }
 
   @Test
-  public void testPlanReadRegressionSingleByteObject() {
+  public void testPlanReadRegressionSingleByteObject() throws IOException {
     // Given: a single byte object and an empty block store
     final int OBJECT_SIZE = 1;
     MetadataStore metadataStore = getTestMetadataStoreWithContentLength(OBJECT_SIZE);
@@ -120,7 +121,8 @@ public class IOPlannerTest {
     assertEquals(expected, missingRanges);
   }
 
-  private MetadataStore getTestMetadataStoreWithContentLength(long contentLength) {
+  private MetadataStore getTestMetadataStoreWithContentLength(long contentLength)
+      throws IOException {
     MetadataStore mockMetadataStore = mock(MetadataStore.class);
     when(mockMetadataStore.get(any()))
         .thenReturn(ObjectMetadata.builder().contentLength(contentLength).build());

--- a/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/MetadataStoreTest.java
+++ b/input-stream/src/test/java/software/amazon/s3/analyticsaccelerator/io/physical/data/MetadataStoreTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import software.amazon.s3.analyticsaccelerator.TestTelemetry;
@@ -34,7 +35,7 @@ import software.amazon.s3.analyticsaccelerator.util.S3URI;
 public class MetadataStoreTest {
 
   @Test
-  public void test__get__cacheWorks() {
+  public void test__get__cacheWorks() throws IOException {
     // Given: a MetadataStore with caching turned on
     ObjectClient objectClient = mock(ObjectClient.class);
     when(objectClient.headObject(any()))
@@ -54,7 +55,7 @@ public class MetadataStoreTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void test__close__closesAllElements() {
+  public void test__close__closesAllElements() throws IOException {
     // Given:
     // - a MetadataStore with caching turned on
     // - an Object Client returning a hanging future that throws when closed

--- a/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/ExecutionBase.java
+++ b/input-stream/src/testFixtures/java/software/amazon/s3/analyticsaccelerator/access/ExecutionBase.java
@@ -34,13 +34,6 @@ public abstract class ExecutionBase {
   protected abstract S3ExecutionContext getS3ExecutionContext();
 
   /**
-   * Returns current client kind
-   *
-   * @return {@link S3ClientKind}
-   */
-  protected abstract S3ClientKind getClientKind();
-
-  /**
    * Creates an instance of {@link S3AsyncClientStreamReader} that uses {@link
    * software.amazon.awssdk.services.s3.S3AsyncClient} to read from S3
    *
@@ -75,16 +68,20 @@ public abstract class ExecutionBase {
   /**
    * Executes a pattern directly on an S3 Client.
    *
+   * @param s3ClientKind S3 client kind to use
    * @param s3Object {@link } S3 Object to run the pattern on
    * @param streamReadPattern the read pattern
    * @param checksum checksum to update, if specified
    * @throws IOException IO error, if thrown
    */
   protected void executeReadPatternDirectly(
-      S3Object s3Object, StreamReadPattern streamReadPattern, Optional<Crc32CChecksum> checksum)
+      S3ClientKind s3ClientKind,
+      S3Object s3Object,
+      StreamReadPattern streamReadPattern,
+      Optional<Crc32CChecksum> checksum)
       throws IOException {
     try (S3AsyncClientStreamReader s3AsyncClientStreamReader =
-        this.createS3AsyncClientStreamReader(getClientKind())) {
+        this.createS3AsyncClientStreamReader(s3ClientKind)) {
       s3AsyncClientStreamReader.readPattern(s3Object, streamReadPattern, checksum);
     }
   }
@@ -92,6 +89,7 @@ public abstract class ExecutionBase {
   /**
    * Executes a pattern on DAT
    *
+   * @param s3ClientKind S3 client kind to use
    * @param s3Object {@link S3Object} S3 Object to run the pattern on
    * @param DATInputStreamConfigurationKind DAT configuration
    * @param streamReadPattern the read pattern
@@ -99,13 +97,14 @@ public abstract class ExecutionBase {
    * @throws IOException IO error, if thrown
    */
   protected void executeReadPatternOnDAT(
+      S3ClientKind s3ClientKind,
       S3Object s3Object,
       StreamReadPattern streamReadPattern,
       DATInputStreamConfigurationKind DATInputStreamConfigurationKind,
       Optional<Crc32CChecksum> checksum)
       throws IOException {
     try (S3DATClientStreamReader s3DATClientStreamReader =
-        this.createS3DATClientStreamReader(getClientKind(), DATInputStreamConfigurationKind)) {
+        this.createS3DATClientStreamReader(s3ClientKind, DATInputStreamConfigurationKind)) {
       executeReadPatternOnDAT(s3Object, s3DATClientStreamReader, streamReadPattern, checksum);
     }
   }

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/S3SdkObjectClient.java
@@ -15,7 +15,12 @@
  */
 package software.amazon.s3.analyticsaccelerator;
 
+import java.io.UncheckedIOException;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import lombok.Getter;
 import lombok.NonNull;
 import org.slf4j.Logger;
@@ -28,7 +33,9 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.ConfigurableTelemetry;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Operation;
 import software.amazon.s3.analyticsaccelerator.common.telemetry.Telemetry;
+import software.amazon.s3.analyticsaccelerator.exceptions.ExceptionHandler;
 import software.amazon.s3.analyticsaccelerator.request.*;
+import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 /** Object client, based on AWS SDK v2 */
 public class S3SdkObjectClient implements ObjectClient {
@@ -134,7 +141,8 @@ public class S3SdkObjectClient implements ObjectClient {
                 headObjectResponse ->
                     ObjectMetadata.builder()
                         .contentLength(headObjectResponse.contentLength())
-                        .build()));
+                        .build())
+            .exceptionally(handleException(headRequest.getS3Uri())));
   }
 
   /**
@@ -193,7 +201,20 @@ public class S3SdkObjectClient implements ObjectClient {
         s3AsyncClient
             .getObject(builder.build(), AsyncResponseTransformer.toBlockingInputStream())
             .thenApply(
-                responseInputStream ->
-                    ObjectContent.builder().stream(responseInputStream).build()));
+                responseInputStream -> ObjectContent.builder().stream(responseInputStream).build())
+            .exceptionally(handleException(getRequest.getS3Uri())));
+  }
+
+  private <T> Function<Throwable, T> handleException(S3URI s3Uri) {
+    return throwable -> {
+      Throwable cause =
+          Optional.ofNullable(throwable.getCause())
+              .filter(
+                  t ->
+                      throwable instanceof CompletionException
+                          || throwable instanceof ExecutionException)
+              .orElse(throwable);
+      throw new UncheckedIOException(ExceptionHandler.toIOException(cause, s3Uri));
+    };
   }
 }

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/exceptions/ExceptionHandler.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/exceptions/ExceptionHandler.java
@@ -75,6 +75,21 @@ public enum ExceptionHandler {
         .orElseGet(() -> createIOException("Error accessing %s", uri, cause));
   }
 
+  /**
+   * Provides sample exceptions for all the exception types handled
+   *
+   * @return An array of exceptions
+   */
+  public static Exception[] getSampleExceptions() {
+    return new Exception[] {
+      NoSuchKeyException.builder().build(),
+      InvalidObjectStateException.builder().build(),
+      SdkClientException.builder().build(),
+      S3Exception.builder().build(),
+      SdkException.builder().build()
+    };
+  }
+
   private static IOException createIOException(String message, S3URI uri, Throwable cause) {
     return new IOException(String.format(message, uri), cause);
   }

--- a/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/exceptions/ExceptionHandler.java
+++ b/object-client/src/main/java/software/amazon/s3/analyticsaccelerator/exceptions/ExceptionHandler.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.s3.analyticsaccelerator.exceptions;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.stream.Stream;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.model.InvalidObjectStateException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.s3.analyticsaccelerator.util.S3URI;
+
+/** Handles mapping of S3 exceptions to IO exceptions. */
+public enum ExceptionHandler {
+  NO_SUCH_KEY(
+      NoSuchKeyException.class,
+      (cause, uri) -> createFileNotFoundException("Object not found %s", uri)),
+
+  INVALID_OBJECT_STATE(
+      InvalidObjectStateException.class,
+      (cause, uri) -> createIOException("Object %s is in invalid state", uri, cause)),
+
+  SDK_CLIENT(
+      SdkClientException.class,
+      (cause, uri) -> createIOException("Client error accessing %s", uri, cause)),
+
+  S3_SERVICE(
+      S3Exception.class,
+      (cause, uri) -> createIOException("Server error accessing %s", uri, cause)),
+
+  SDK_GENERAL(
+      SdkException.class, (cause, uri) -> createIOException("SDK error accessing %s", uri, cause));
+
+  private final Class<? extends Exception> exceptionClass;
+  private final ExceptionMapper mapper;
+
+  @FunctionalInterface
+  private interface ExceptionMapper {
+    IOException toIOException(Throwable cause, S3URI uri);
+  }
+
+  ExceptionHandler(Class<? extends Exception> exceptionClass, ExceptionMapper mapper) {
+    this.exceptionClass = exceptionClass;
+    this.mapper = mapper;
+  }
+
+  /**
+   * Maps the passed exception to an IOException, if possible. Otherwise, returns a generic
+   * IOException wrapping the passed exception.
+   *
+   * @param cause The exception to be mapped
+   * @param uri The S3URI that caused the exception
+   * @return An IOException
+   */
+  public static IOException toIOException(Throwable cause, S3URI uri) {
+    return Stream.of(values())
+        .filter(handler -> handler.exceptionClass.isInstance(cause))
+        .findFirst()
+        .map(handler -> handler.mapper.toIOException(cause, uri))
+        .orElseGet(() -> createIOException("Error accessing %s", uri, cause));
+  }
+
+  private static IOException createIOException(String message, S3URI uri, Throwable cause) {
+    return new IOException(String.format(message, uri), cause);
+  }
+
+  private static FileNotFoundException createFileNotFoundException(String message, S3URI uri) {
+    return new FileNotFoundException(String.format(message, uri));
+  }
+}

--- a/object-client/src/test/java/software/amazon/s3/analyticsaccelerator/exceptions/ExceptionHandlerTest.java
+++ b/object-client/src/test/java/software/amazon/s3/analyticsaccelerator/exceptions/ExceptionHandlerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.s3.analyticsaccelerator.exceptions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.model.InvalidObjectStateException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.s3.analyticsaccelerator.util.S3URI;
+
+public class ExceptionHandlerTest {
+  private static final S3URI TEST_URI = S3URI.of("test-bucket", "test-key");
+
+  @Test
+  void testHandleNoSuchKeyException() {
+    NoSuchKeyException cause = NoSuchKeyException.builder().build();
+    IOException exception = ExceptionHandler.toIOException(cause, TEST_URI);
+    assertInstanceOf(FileNotFoundException.class, exception);
+    assertInstanceOf(IOException.class, exception);
+    assertNull(exception.getCause());
+  }
+
+  @Test
+  void testHandleInvalidObjectStateException() {
+    InvalidObjectStateException cause = InvalidObjectStateException.builder().build();
+    IOException exception = ExceptionHandler.toIOException(cause, TEST_URI);
+    assertInstanceOf(IOException.class, exception);
+    assertSame(cause, exception.getCause());
+  }
+
+  @Test
+  void testHandleSdkClientException() {
+    SdkClientException cause = SdkClientException.builder().build();
+    IOException exception = ExceptionHandler.toIOException(cause, TEST_URI);
+    assertInstanceOf(IOException.class, exception);
+    assertSame(cause, exception.getCause());
+  }
+
+  @Test
+  void testHandleS3Exception() {
+    AwsServiceException cause = S3Exception.builder().build();
+    IOException exception = ExceptionHandler.toIOException(cause, TEST_URI);
+    assertInstanceOf(IOException.class, exception);
+    assertSame(cause, exception.getCause());
+  }
+
+  @Test
+  void testHandleSdkException() {
+    RuntimeException cause = SdkException.builder().build();
+    IOException exception = ExceptionHandler.toIOException(cause, TEST_URI);
+    assertInstanceOf(IOException.class, exception);
+    assertSame(cause, exception.getCause());
+  }
+
+  @Test
+  void testHandleRuntimeException() {
+    RuntimeException cause = new RuntimeException();
+    IOException exception = ExceptionHandler.toIOException(cause, TEST_URI);
+    assertInstanceOf(IOException.class, exception);
+    assertSame(cause, exception.getCause());
+  }
+}


### PR DESCRIPTION

## Description of change
- Ensure integration tests run for both S3 Client Kinds
- Add more unit tests for ObjectClient and S3SeekableInputStreamFactory



#### Does this contribution introduce any breaking changes to the existing APIs or behaviors? NO

#### Does this contribution introduce any new public APIs or behaviors? NO

#### How was the contribution tested? Unit and Integration tests

#### Does this contribution need a changelog entry? NO
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).